### PR TITLE
Changes in inline images and fonts

### DIFF
--- a/src/main/java/PDLayer.mdl
+++ b/src/main/java/PDLayer.mdl
@@ -143,13 +143,15 @@ type PDFont extends PDResource {
 	property Subtype: String;
 	% base font name (BaseFont entry)
 	property BaseFont: String;
+	% true if the font flags in the font descriptor dictionary mark indicate that the font is symbolic (the entry /Flags has bit 3 set to 1 and bit 6 set to 0)
+	property isSymbolic: Boolean;
 	% embedded font program for Type 1, TrueType or CID Font
 	link fontFile: FontProgram?;
 }
 
 % One of the simple font types (Type 1, TrueType, Type 3)
 type PDSimpleFont extends PDFont {
-	% True if the font is one of the 14 standard fonts defined in PDF 1.4 Reference
+	% true if the font is one of the 14 standard fonts defined in PDF 1.4 Reference
 	property isStandard: Boolean;
 	% FirstChar entry; null if LastChar entry is not present or has invalid type
 	property FirstChar: Integer;
@@ -157,6 +159,12 @@ type PDSimpleFont extends PDFont {
 	property LastChar: Integer;
 	% The size of the Widths array; null if the Widths array is not present or has invalid type
 	property Widths_size: Integer;
+	% String representation of the font encoding: 
+	% - null if the /Encoding entry is not present in the font dictionary
+	% - if /Encoding entry in the font dictionary if of Name type, then the value of this entry;
+	% - if /Encoding entry is a dictionary, which does not contain /Differences array, then the value of /BaseEncoding entry in this dictionary (or null, if /BaseEncoding is also not present)
+	% - the string "Custom", of the /Encoding entry is a dictionary containing /Differences key
+	property Encoding: String;
 }
 
 type PDType3Font extends PDSimpleFont {


### PR DESCRIPTION
- moved the link to the inline image dictionary to Operator_ID
- added symbolic flag to PDFont
- added Encoding property to PDSimpleFont
