### PR TITLE
REL - Development version v1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: java
 
 jdk:
-  - openjdk7
+  - openjdk8
   - oraclejdk8
+  - oraclejdk9
 
 branches:
   except:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Pre-requisites
 --------------
 In order to generate the model classes you'll need:
 
- * Java 7, which can be downloaded [from Oracle](http://www.oracle.com/technetwork/java/javase/downloads/index.html), or for Linux users [OpenJDK](http://openjdk.java.net/install/index.html).
+ * Java 8, which can be downloaded [from Oracle](http://www.oracle.com/technetwork/java/javase/downloads/index.html), or for Linux users [OpenJDK](http://openjdk.java.net/install/index.html).
  * [Maven v3+](https://maven.apache.org/)
 
 If you want to edit and regenerate the model you'll need:

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.verapdf</groupId>
     <artifactId>verapdf-parent</artifactId>
-    <version>1.12</version>
+    <version>1.12.1</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,13 @@
   <parent>
     <groupId>org.verapdf</groupId>
     <artifactId>verapdf-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.12</version>
     <relativePath />
   </parent>
 
   <groupId>org.verapdf</groupId>
   <artifactId>pdf-model</artifactId>
-  <version>1.10.0</version>
+  <version>1.11.0-SNAPSHOT</version>
 
   <name>veraPDF Validation Model API</name>
   <description>Java interfacts for the veraPDF Validation model, generated from the Xtext DSL.</description>
@@ -70,30 +70,10 @@
 
   <properties>
     <verapdf.model.syntax.version>[1.0.0,2.0.0)</verapdf.model.syntax.version>
-    <xtext.version>2.8.3</xtext.version>
+    <xtext.version>2.13.0</xtext.version>
   </properties>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>2.4</version>
-          <executions>
-            <!-- here we override the super-pom attach-sources executionid which
-            calls sources:jar goal. That goals forks the lifecycle, causing
-            the generate-sources phase to be called twice for the install goal.
-            This causes any other plugin bound to the generate-sources phase to
-            be called twice which usually has nasty side effects, let alone
-            creating duplicate processing and longer build times. -->
-            <execution>
-              <id>attach-sources</id>
-              <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -171,6 +151,16 @@
          <artifactId>maven-source-plugin</artifactId>
          <inherited>true</inherited>
          <executions>
+           <!-- here we override the super-pom attach-sources executionid which
+           calls sources:jar goal. That goals forks the lifecycle, causing
+           the generate-sources phase to be called twice for the install goal.
+           This causes any other plugin bound to the generate-sources phase to
+           be called twice which usually has nasty side effects, let alone
+           creating duplicate processing and longer build times. -->
+           <execution>
+             <id>attach-sources</id>
+             <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase>
+           </execution>
            <execution>
              <id>attach-sources-no-fork</id>
              <inherited>true</inherited>
@@ -183,7 +173,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.8</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>


### PR DESCRIPTION
- bumped minor -> 1.11 for development;
- now using veraPDF parent POM v1.12;
- updated xtext plugin version -> 2.13;
- small tidy ups to  plugin management; and
- updated build helper maven plugin version.