### PR TITLE
Add properies L and streamLength to PDInlineImage

### DIFF
--- a/src/main/java/PDLayer.mdl
+++ b/src/main/java/PDLayer.mdl
@@ -464,6 +464,10 @@ type PDMaskImage extends PDXImage {
 
 % Inline image object
 type PDInlineImage extends PDXImage {
+    % value of the L key
+	property L: Integer;
+	% actual stream length
+    property streamLength: Integer;
 	% link to the inline image filters
 	link F: CosIIFilter*;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline image information now includes the declared length value and the actual inline image stream length.
  * This enhances visibility into inline image data, helping supported document workflows better understand and validate inline image size details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->